### PR TITLE
Added quiz results output in markdown format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ docs/notes
 
 # zip files
 *.zip
+
+# results
+results

--- a/src/pyquiz.py
+++ b/src/pyquiz.py
@@ -1,7 +1,6 @@
 # src/pyquiz.py
 
 import os
-import sys
 import datetime
 import pyfiglet
 import random
@@ -579,7 +578,9 @@ class Result:
         """
         Returns the result in html format.
         """
-        return "<p><strong>Question:</strong> {}</p><p><strong>Your answer:</strong> {}</p><p><strong>Correct answer:</strong> {}</p><p><strong>Result:</strong> {}</p>".format(self.question.question_text, self.answer, self.correct_answer, self.result)
+        # ignore ruff line too long
+        # pylint: disable=line-too-long
+        return "<p><strong>Question:</strong> {}</p><p><strong>Your answer:</strong> {}</p><p><strong>Correct answer:</strong> {}</p><p><strong>Result:</strong> {}</p>".format(self.question.question_text, self.answer, self.correct_answer, self.result) # noqa: E501
     
 class QuizResults:
     """
@@ -624,7 +625,7 @@ class QuizResults:
         """
         # summary
         print("Quiz Results Summary:")
-        print("Per the results, you scored {}/{}.".format(self.score, len(self.results)))
+        print("You scored {}/{}.".format(self.score, len(self.results)))
         print()
 
     def display_results(self):


### PR DESCRIPTION
Now, when running the sample Python quiz, the following markdown file is generated:
* `results/python/2023-04-25-20-16-09-quiz-results.md`
```
## python
## Quiz Results
### Summary:
**Date:** 2023-04-25-20-16-09

**Score:** 4/5

**Percentage:** 80.0%

---
### Questions:
#### Q2. Sample question 2?

- [ ] Answer 1
- [ ] Answer 2
- [x] Answer 3
- [ ] Answer 4



**Your answer:** 3

**Correct answer:** 3

**Result:** True



---

#### Q123.

```python
# some code

```

- [x] A

```python
# some code

```

- [ ] B

```python
# some code

```

- [ ] C

```python
# some code

```

- [ ] D

```python
# some code

```

**Explanation:** This is some crazy code!

[Reference](http://www.example.com)


**Your answer:** 2

**Correct answer:** 2

**Result:** True



---

#### Q4. Sample question 4?

- [ ] Answer 1
- [ ] Answer 2
- [x] Answer 3
- [ ] Answer 4



**Your answer:** 3

**Correct answer:** 3

**Result:** True



---

#### Q3. Sample question 3?

```
# this is some code
print("Hello World")

```

- [ ] Answer 1
- [ ] Answer 2
- [x] Answer 3
- [ ] Answer 4



**Your answer:** 3

**Correct answer:** 3

**Result:** True



---

#### Q7. Sample question 7?

- [ ] Answer 1
- [ ] Answer 2
- [x] Answer 3
- [ ] Answer 4



**Your answer:** 1

**Correct answer:** 3

**Result:** False



---

```
